### PR TITLE
Resolvendo caso de teste em que usuário insere id diferente do id per…

### DIFF
--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -41,6 +41,14 @@ export async function autenticarToken(
     })
     return
   }
+  if(req.body.usuario_id){
+    if(req.body.usuario_id != id){
+      res.status(401).json({
+        Erro: "Usuario errado"
+      })
+      return
+    }
+   }
   //TODO: Adicionar verificaçõpes de usuário com conteúdo do req.body
   next();
 }

--- a/src/routes/testarrota.spec.ts
+++ b/src/routes/testarrota.spec.ts
@@ -207,5 +207,6 @@ describe("Testar erro de acesso",()=>{
             usuario_id : usuario2.id
         });
         expect(responseacao.status).toBe(401);
+        expect(responseacao.body.Erro).toBe("Usuario errado");
     });
 });


### PR DESCRIPTION
Usuário antes poderia usar seu token, porém o id de outro usuário, para fazer operações na conta de outro usuário.
Agora, foi adicionado uma verificação na função autenticartoken, em que no caso de rotas que pedem o id do usuário para mexer em dados referentes a sua conta, irá verificar se o id fornecido pertence ao id do token.